### PR TITLE
[SDK-11431] Updates the package minimum to iOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "JWPlayerKit",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v14)
     ],
     products: [
         .library(


### PR DESCRIPTION
This should have been done back in 4.17, when the SDK set the new minimum to iOS 14.
